### PR TITLE
Erreur sur la variance et changement de la methoe d inversion

### DIFF
--- a/geostats/geostat.py
+++ b/geostats/geostat.py
@@ -345,8 +345,8 @@ def ordinary_kriging_covariance(x, v, xu, covar):
     b[0:n_data, 0:n_unknown] = c[n_unknown:n_total, 0:n_unknown]
 
     # Solve the Kriging system
-    l = np.dot(np.linalg.inv(a), b)
-
+    l=np.linalg.solve(a,b)
+    
     # Get the Kriging weight for each data point
     w = l[0:n_data, 0:n_unknown]
 
@@ -404,7 +404,7 @@ def ordinary_kriging_variogram(x, v, xu, vario):
     b[0:n_data, 0:n_unknown] = g[n_unknown:n_total, 0:n_unknown]
 
     # Solve the Kriging system
-    l = np.dot(np.linalg.inv(a), b)
+    l=np.linalg.solve(a,b)
 
     # Get the Kriging weight for each data point
     w = l[0:n_data, 0:n_unknown]

--- a/geostats/geostat.py
+++ b/geostats/geostat.py
@@ -363,7 +363,7 @@ def ordinary_kriging_covariance(x, v, xu, covar):
     # Computes the kriging variance for each unknown point
     so = np.diag(np.dot(np.transpose(w), b[0:n_data, :]))
     so.shape = (n_unknown, 1)
-    so = so + covar._sill - mu
+    so = -so + covar._sill - mu
 
     return vo, so
 

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='geostats',
       author='Philippe Renard',
       author_email='philippe.renard@unine.ch',
       license='MIT',
-      packages=['geostat'],
+      packages=['geostats'],
       zip_safe=False)


### PR DESCRIPTION
Dans la fonction krigeage apr coorélation, il y avait une erreur sur le calcul de la variance. Il manquait un "-"

Pour calculer les poids j'ai changé la méthode en utilisant np.linalg.solve qui resoud un systeme lineaire. D'arpès Przemek c'est plus stable comme fonction.